### PR TITLE
added bower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea
+*.log

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "console.js",
+  "version": "0.0.1",
+  "homepage": "https://github.com/icodeforlove/Console.js",
+  "authors": [
+    {
+      "name": "Chad Scira"
+    }
+  ],
+  "description": "Easy coloured console logs",
+  "main": "console.js",
+  "keywords": [
+    "console",
+    "colour",
+    "log"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/icodeforlove/Console.js.git"
+  }
+}


### PR DESCRIPTION
This way you can register this package with the bower registry and people can download and use Console.js right after a simple `bower install Console.js`.